### PR TITLE
Align GenerateRequest with ReportInput

### DIFF
--- a/api/generate.py
+++ b/api/generate.py
@@ -1,17 +1,12 @@
 from fastapi import APIRouter
-from pydantic import BaseModel
+from schema.report import ReportInput
 from core.builder import ReportBuilder
 from core.llm_factory import create_llm
 
 router = APIRouter()
 
-class GenerateRequest(BaseModel):
-    stay_id: int
-    predicted_risk: float
-    features: dict[str, float | int | str]
-    shap_values: dict[str, float]
-    model: str = "gemini"
-    prompt_code: str = "P1"
+class GenerateRequest(ReportInput):
+    pass
 
 @router.post("/generate")
 def generate(req: GenerateRequest):


### PR DESCRIPTION
## Summary
- reuse schema `ReportInput` for `GenerateRequest`
- update endpoint to use inherited schema

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694bf0ad608331b47a03f6bec2bdc0