### PR TITLE
Add prompt templates and builder selection

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -1,3 +1,7 @@
+"""Prompt templates used throughout the application."""
+
 PROMPTS = {
     "P1": "You are an ICU physician preparing a report.",
+    "P2": "You are a concise ICU doctor summarizing patient risk.",
+    "P3": "You are a senior ICU expert giving medical advice.",
 }

--- a/tests/test_report_builder_prompt.py
+++ b/tests/test_report_builder_prompt.py
@@ -1,0 +1,30 @@
+import sys
+import types
+
+if "pandas" not in sys.modules:
+    pandas_stub = types.ModuleType("pandas")
+    pandas_stub.DataFrame = object
+    pandas_stub.read_csv = lambda *a, **k: None
+    sys.modules["pandas"] = pandas_stub
+
+from core.builder import ReportBuilder
+from schema.report import ReportInput
+from core.llm_client_base import LLMClient
+from prompts import PROMPTS
+
+class DummyClient(LLMClient):
+    def __init__(self):
+        self.system_prompt = None
+    def chat(self, system_prompt: str, user_prompt: str):
+        self.system_prompt = system_prompt
+        return "", {}
+
+def _make_input():
+    return ReportInput(stay_id=1, predicted_risk=0.1, features={}, shap_values={})
+
+def test_prompt_templates_used():
+    for code, template in PROMPTS.items():
+        llm = DummyClient()
+        builder = ReportBuilder(llm, code)
+        builder.build(_make_input())
+        assert llm.system_prompt.startswith(template)


### PR DESCRIPTION
## Summary
- add more prompt templates
- select the proper template in `ReportBuilder`
- test that the correct template is used for each `prompt_code`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694bf6e58c83319208684e65f32308